### PR TITLE
Added a parser for golang's Gopkg.lock

### DIFF
--- a/patton_client/libraries_parsers/__init__.py
+++ b/patton_client/libraries_parsers/__init__.py
@@ -6,6 +6,7 @@ from .simple import simple_parser
 from .dpkg import dpkg_parser
 from .python import python_parser
 from .alpine import alpine_parser
+from .golang import golang_parser
 
 
 DEPENDENCIES_PARSERS = {
@@ -13,7 +14,8 @@ DEPENDENCIES_PARSERS = {
     'simple_parser': simple_parser,
     'dpkg': dpkg_parser,
     'python': python_parser,
-    'alpine': alpine_parser
+    'alpine': alpine_parser,
+    'golang': golang_parser
 }
 
 
@@ -40,4 +42,3 @@ def parse_dependencies(dependencies: List[List[str]],
         result.update(parser(fixed_source, patton_config))
 
     return result
-

--- a/patton_client/libraries_parsers/golang.py
+++ b/patton_client/libraries_parsers/golang.py
@@ -1,0 +1,26 @@
+import re
+import logging
+
+from typing import List, Dict
+
+from patton_client import PattonRunningConfig, PCException
+
+log = logging.getLogger("patton-cli")
+
+def golang_parser(lines: str, config: PattonRunningConfig) -> Dict:
+
+    def clean(s):
+        return s.strip().replace('"', '')
+
+    results = {}
+
+    lines = lines[:lines.find("[solve-meta]")].strip()
+    content = "\n".join([line for line in lines.split("\n") if not line.startswith("#") and line != ""])
+    projects = [project.strip() for project in content.split("[[projects]]") if project != '']
+
+    for project in projects:
+        project_dict = {clean(val.split(" = ")[0]): clean(val.split(" = ")[1]) for val in project.split("\n")}
+        version = project_dict.get("version") or project_dict.get("revision", "")
+        results[project_dict["name"]] = version
+
+    return results


### PR DESCRIPTION
In this PR I add a parser for golang's Gopkg.lock file.

Usage: 
`cat Gopkg.lock | patton -e golang`

Currently Golang's package versioning is still somewhat green, but the biggest solution right now is https://github.com/golang/dep
